### PR TITLE
Add new features to conda-api: create, install, process

### DIFF
--- a/conda.recipe/bld.bat
+++ b/conda.recipe/bld.bat
@@ -1,0 +1,2 @@
+python setup.py install
+if errorlevel 1 exit 1

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pushd $RECIPE_DIR/..
+$PYTHON setup.py install

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,0 +1,17 @@
+package:
+  name: conda-api
+  version: 1.2.0
+
+requirements:
+  build:
+    - python
+  run:
+    - python
+
+test:
+  imports:
+    - conda_api
+
+about:
+  home: https://github.com/conda/conda-api
+  license: BSD

--- a/conda.recipe/run_test.py
+++ b/conda.recipe/run_test.py
@@ -1,0 +1,19 @@
+import sys
+from os.path import expanduser
+
+import conda_api
+
+assert (conda_api.split_canonical_name('redis-py-2.4.3-py27_0') ==
+        ('redis-py', '2.4.3', 'py27_0'))
+
+print('conda_api.__version__: %s' % conda_api.__version__)
+
+if sys.platform.startswith('win32'):
+    root_prefix = r'C:\Python27'
+else:
+    root_prefix = expanduser('~/minonda')
+
+conda_api.set_root_prefix(root_prefix)
+conda_api.test()
+
+assert conda_api.__version__ == '1.2.0'


### PR DESCRIPTION
Updated conda-api package to support:
- `conda_api.create`
- `conda_api.install`
- automatic `ROOT_PREFIX` discovery with `conda_api.set_root_prefix()` (no args will guess)
- `conda_api.process`: creation in a specified conda env

Updated version to 1.2.0
